### PR TITLE
feat!: Updates to Slack API, Source Control API, and template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 dist/*
 node_modules/*
 
+# IntelliJ Local files
+.idea/

--- a/changelog.config.js
+++ b/changelog.config.js
@@ -15,7 +15,7 @@ module.exports = {
       // Auth token of the user to login with
       // https://confluence.atlassian.com/cloud/api-tokens-938839638.html
       token: undefined,
-      // If you need to set some jira-client option use this object. 
+      // If you need to set some jira-client option use this object.
       // Check jira-client docs for available options: https://jira-node.github.io/typedef/index.html#static-typedef-JiraApiOptions
       options: {},
     },
@@ -75,8 +75,8 @@ module.exports = {
     // This can include from/to git commit references
     // and or after/before datestamps.
     defaultRange: {
-      from: "origin/prod",
-      to: "origin/stage",
+      from: "upstream/release",
+      to: "upstream/master",
 
       // symmetric='...'
       // non-symmetric='..'
@@ -127,7 +127,7 @@ Jira Tickets
 Other Commits
 ---------------------
 <% blockNoTickets.forEach(commit => { -%>
-  * <%= commit.slackUser ? '@'+commit.slackUser.name : commit.authorName %> - <<%= commit.revision.substr(0, 7) %>> - <%= commit.summary %>
+  * <<%= commit.revision.substr(0, 7) %>> - <%= commit.summary %>
 <% }); -%>
 <% if (!blockNoTickets.length) {%> ~ None ~ <% } %>
 <% } -%>
@@ -137,7 +137,7 @@ Other Commits
 Pending Approval
 ---------------------
 <% blockPendingByOwner.forEach(owner => { -%>
-<%= (owner.slackUser) ? '@'+owner.slackUser.name : owner.email %>
+<%= owner.email %>
 <% owner.tickets.forEach((ticket) => { -%>
   * <%= jira.baseUrl + '/browse/' + ticket.key %>
 <% }); -%>
@@ -145,6 +145,7 @@ Pending Approval
 <% if (!blockPendingByOwner.length) {%> ~ None. Yay! ~ <% } -%>
 <% } -%>
 <% if (tickets.reverted.length) { %>
+
 Reverted
 ---------------------
 <% tickets.reverted.forEach((ticket) => { -%>

--- a/src/Jira.js
+++ b/src/Jira.js
@@ -231,10 +231,9 @@ export default class Jira {
 
   /**
    * Retreive the jira issue by ID.
-   * Also attempt to match a slack user to the reporter's email address.
    *
    * @param {String} ticketId - The ticket ID of the issue to retrieve.
-   * @return {Promise} Resolves a jira issue object, with added `slackUser` property.
+   * @return {Promise} Resolves a jira issue object.
    */
   async getJiraIssue(ticketId) {
     if (!this.jira) {
@@ -243,14 +242,7 @@ export default class Jira {
 
     return this.jira.findIssue(ticketId).then((origTicket) => {
       const ticket = Object.assign({}, origTicket);
-      if (!this.config.slack.api || !ticket.fields.reporter)
-        return ticket;
-      return this.slack.findUser(ticket.fields.reporter.emailAddress, ticket.fields.reporter.displayName)
-      .then((slackUser) => {
-        ticket.slackUser = slackUser;
-        return ticket;
-      })
-      .catch(() => ticket);
+      return ticket;
     });
   }
 

--- a/src/Slack.js
+++ b/src/Slack.js
@@ -1,14 +1,6 @@
 import fetch from 'node-fetch';
-import urlencoded from 'form-urlencoded';
 
-const API_ROOT = 'https://slack.com/api/';
 const MSG_SIZE_LIMIT = 4000;
-
-// Cache of GET requests
-const cache = {};
-
-// Cache of pending GET requests
-const pending = {};
 
 /**
  * Manages the slack integration.
@@ -17,117 +9,46 @@ export default class Slack {
 
   constructor(config) {
     this.config = config;
-    this.slackUsers = false;
   }
 
   /**
    * Is the slack integration enabled
    */
   isEnabled() {
-    return (this.config.slack && this.config.slack.apiKey);
+    return (this.config.slack && this.config.slack.webhookURL);
   }
 
   /**
-   * Make an API call and return the repsponse
+   * Post message chunk to webhook URL
    *
-   * @param {String} endpoint - The API endpoint name. (i.e 'users.list')
-   * @param {String} method - The HTTP method to use (i.e. GET)
-   * @param {Object} body - The request body for POST or PUT. This will be serialized to application/x-www-form-urlencoded
+   * @param {Object} body - The request body containing the text to POST to the webhook URL
    *
    * @return {Promise}
    */
-  api(endpoint, method='GET', body=undefined) {
-    const headers = {};
-    const cachable = (method.toUpperCase() == 'GET');
-    const url = `${API_ROOT}/${endpoint}?token=${this.config.slack.apiKey}`;
+  postChunk(body) {
+    const url = `${this.config.slack.webhookURL}`;
 
     if (!this.isEnabled()) {
       return Promise.reject('The slack API is not configured.');
     }
 
-    if (typeof body === 'object') {
-      body = urlencoded(body);
-    }
-    if (method === 'POST') {
-      headers['Content-Type'] = 'application/x-www-form-urlencoded';
-    }
-    else if (cachable && cache[url]) {
-      return Promise.resolve(cache[url]);
-    }
-    else if (method === 'GET' && pending[url]) {
-      return pending[url];
-    }
+    const messageBody = {
+      "username": "Changelog notifier",
+      "text": "Changelog published",
+      "blocks": [
+        {
+          "type": "section",
+          "text": {
+            "type": "mrkdwn",
+            "text": body
+          }
+        }
+      ]
+    };
 
-    pending[url] = fetch(url, { method, body, headers })
-    .then(res => res.json())
+    return fetch(url, { method: 'POST', body: JSON.stringify(messageBody), headers: { 'Content-Type': 'application/json' } })
     .then((data) => {
-      // Cache result
-      if (cachable && data && data.ok) {
-        cache[url] = data;
-      }
       return data;
-    });
-
-    return pending[url];
-  }
-
-  /**
-   * Load all the slack users.
-   *
-   * @returns {Promise} Resolves to the user object list
-   */
-  getSlackUsers() {
-
-    // No slack integration
-    if (!this.isEnabled()) {
-      return Promise.resolve([]);
-    }
-
-    // Already loaded users
-    if (this.slackUsers) {
-      return Promise.resolve(this.slackUsers);
-    }
-
-    // Get users
-    return this.api("users.list")
-    .then((response) => {
-      if (!response || response.error) {
-        const err = (response) ? response.error : 'No response from server';
-        console.error('Could not load slack users:', err);
-        return Promise.reject(err);
-      }
-
-      this.slackUsers = response.members;
-      return this.slackUsers;
-    });
-  }
-
-  /**
-   * Try to find a slack user by email and/or name
-   *
-   * @param {String} email - The email address to use to lookup the slack user.
-   * @param {String} name - The full name to use to lookup the slack user.
-   * @return {Promise} Resolves to the slack user object or undefined
-   */
-  findUser(email, name) {
-    return this.getSlackUsers()
-    .then((users) => {
-
-      // Try by email first (more exact match)
-      email = email.toLowerCase();
-      let found = users.find(u => (u.profile.email && u.profile.email.toLowerCase() === email));
-
-      // Fallback to name
-      if (!found && name) {
-        name = name.toLowerCase();
-        found = users.find((u) => {
-          const profile = u.profile;
-          return (profile.real_name && profile.real_name.toLowerCase() === name) ||
-                 (profile.real_name_normalized && profile.real_name_normalized.toLowerCase() === name);
-        });
-      }
-
-      return found;
     });
   }
 
@@ -136,11 +57,10 @@ export default class Slack {
    * If the message is longer than slack's limit, it will be cut into multiple messages.
    *
    * @param {String} text - The message to send to slack
-   * @param {String} channel - The slack channel ID to send the message to. (i.e. `#engineering`)
    *
    * @return {Promise} Resolves when message has sent
    */
-  postMessage(text, channel) {
+  postMessage(text) {
 
     // No message
     if (!text || !text.length) {
@@ -159,18 +79,10 @@ export default class Slack {
       return promise.then(() => sendChunk(text));
     }, Promise.resolve());
 
-    // Sends a single message to the channel and returns a promise
+    // Sends a single message to the webhook URL and returns a promise
     const self = this;
     function sendChunk(text) {
-      return self.api('chat.postMessage', 'POST',
-        {
-          text,
-          channel,
-          parse: 'full',
-          username: self.config.slack.username,
-          icon_emoji: self.config.slack.icon_emoji,
-          icon_url: self.config.slack.icon_url
-        }).then((response) => {
+      return self.postChunk(text).then((response) => {
           if (response && !response.ok) {
             throw response.error;
           }

--- a/src/template.js
+++ b/src/template.js
@@ -91,7 +91,6 @@ export function getTicketReporters(tickets) {
       reporters[email] = {
         email,
         name: displayName,
-        slackUser: ticket.slackUser,
         tickets: [ticket]
       };
     } else {
@@ -210,14 +209,16 @@ export function transformCommitLogs(config, logs) {
  * @param {Object} config - The configuration object
  * @param {Array} changelog - The changelog list.
  * @param {Array} releaseVersions - Jira release versions for this changelog.
+ * @param {Array} info - Release info for this changelog.
  *
  * @return {String}
  */
-export async function generateTemplateData(config, changelog, releaseVersions) {
+export async function generateTemplateData(config, changelog, releaseVersions, info) {
   let data = await transformCommitLogs(config, changelog);
   if (typeof config.transformData == 'function') {
     data = await Promise.resolve(config.transformData(data));
   }
+  data.info = info;
   data.jira = {
     baseUrl: config.jira.baseUrl,
     releaseVersions: releaseVersions,


### PR DESCRIPTION
Add Slack support for webhook URLs and block style messages.

Update Source Control API to use simple-git/promise and remove slackUser filtering logic.

Add additional release info to template including repo directory and changelog date.

BREAKING CHANGE: Remove slackUser support from slack API and template. Remove Slack apiToken support in favor of newer webhook URLs. Change from/to default in sourceControl.defaultRange changelog config.